### PR TITLE
Fix timestamp date when --logfile is a dir and other cases

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -25138,7 +25138,7 @@ lets_roll() {
      fi
 
      [[ -z "$NODE" ]] && parse_hn_port "${URI}"             # NODE, URL_PATH, PORT, IPADDRs and IP46ADDR is set now
-     prepare_logging
+     prepare_logging "${FNAME_DATE}"
 
      if [[ -n "$PROXY" ]] && $DNS_VIA_PROXY; then
           NODEIP="$NODE"


### PR DESCRIPTION

This fixes #3121 , a bug which was introduced in ceb24740a324b7714bea38d7eb170a64b2eb6fb0 because `prepare_logging()` expected an argument to pass the timestamp.

This PR adds `"${FNAME_DATE}"` as it has been in 3.3dev when creating that backport.



## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order of last name) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ ] I found a bug / an improvement using LLM version: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, JetBrains Junie, VS Code plugin <NAME> etc.]`
    - LLMs and versions: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`

