### PR TITLE
Show the UTC offset in the start and done banner

### DIFF
--- a/t/32_isHTML_valid.t
+++ b/t/32_isHTML_valid.t
@@ -79,11 +79,11 @@ $debughtml = `cat $html_file`;
 unlink $html_file;
 
 # Remove date information from the Start and Done banners in the two HTML files, since they were created at different times
-$html =~ s/Start 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]/Start XXXX-XX-XX XX:XX:XX/;
-$debughtml =~ s/Start 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]/Start XXXX-XX-XX XX:XX:XX/;
+$html =~ s/Start 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] \(UTC offset: [+-][0-9][0-9][0-9][0-9]\)/Start XXXX-XX-XX XX:XX:XX (UTC offset: +XXXX)/;
+$debughtml =~ s/Start 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] \(UTC offset: [+-][0-9][0-9][0-9][0-9]\)/Start XXXX-XX-XX XX:XX:XX (UTC offset: +XXXX)/;
 
-$html =~ s/Done 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] \[ *[0-9]*s\]/Done XXXX-XX-XX XX:XX:XX [   Xs]/;
-$debughtml =~ s/Done 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] \[ *[0-9]*s\]/Done XXXX-XX-XX XX:XX:XX [   Xs]/;
+$html =~ s/Done 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] \(UTC offset: [+-][0-9][0-9][0-9][0-9]\) \[ *[0-9]*s\]/Done XXXX-XX-XX XX:XX:XX (UTC offset: +XXXX) [   Xs]/;
+$debughtml =~ s/Done 2[0-9][0-9][0-9]-[0-3][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9] \(UTC offset: [+-][0-9][0-9][0-9][0-9]\) \[ *[0-9]*s\]/Done XXXX-XX-XX XX:XX:XX (UTC offset: +XXXX) [   Xs]/;
 
 # Remove time difference from "HTTP clock skew" line
 $html =~ s/HTTP clock skew              \+?-?[0-9]* /HTTP clock skew              X /;

--- a/testssl.sh
+++ b/testssl.sh
@@ -23627,9 +23627,9 @@ datebanner() {
 
      if [[ "$1" =~ Done ]] ; then
           scan_time_f="$(printf "%04ss" "$SCAN_TIME")"           # 4 digits because of windows
-          pr_reverse "$1 $(date +%F) $(date +%T) [$scan_time_f] -->> $node_banner <<--"
+          pr_reverse "$1 $(date +%F) $(date "+%T %z") [$scan_time_f] -->> $node_banner <<--"
      else
-          pr_reverse "$1 $(date +%F) $(date +%T)        -->> $node_banner <<--"
+          pr_reverse "$1 $(date +%F) $(date "+%T %z")        -->> $node_banner <<--"
      fi
      outln "\n"
      [[ "$1" =~ Start ]] && display_rdns_etc

--- a/testssl.sh
+++ b/testssl.sh
@@ -23627,9 +23627,9 @@ datebanner() {
 
      if [[ "$1" =~ Done ]] ; then
           scan_time_f="$(printf "%04ss" "$SCAN_TIME")"           # 4 digits because of windows
-          pr_reverse "$1 $(date +%F) $(date "+%T %z") [$scan_time_f] -->> $node_banner <<--"
+          pr_reverse "$1 $(date +%F) $(date +%T) (UTC offset: $(date "+%z")) [$scan_time_f] -->> $node_banner <<--"
      else
-          pr_reverse "$1 $(date +%F) $(date "+%T %z")        -->> $node_banner <<--"
+          pr_reverse "$1 $(date +%F) $(date +%T) (UTC offset: $(date "+%z"))        -->> $node_banner <<--"
      fi
      outln "\n"
      [[ "$1" =~ Start ]] && display_rdns_etc


### PR DESCRIPTION
The Start and Done banner prints the local time but nothing tells you which timezone that is, so people don't always know how it relates to the UTC times shown elsewhere (like the certificate validity dates). This adds the local UTC offset to the banner so it is obvious at a glance.

Closes #1907.

Example:

```
 Start 2026-08-24 17:35:20 -0400        -->> 127.0.0.1:4443 (127.0.0.1) <<--
 Done 2026-08-24 17:35:31 -0400 [  18s] -->> 127.0.0.1:4443 (127.0.0.1) <<--
```

I used the numeric `%z` offset because it is portable across GNU and BSD date and it stays correct for the half hour zones like `+0530` where a "+2h" style gets messy. On a host set to UTC it shows `+0000`.

## What is your pull request about?
- [x] Improvement

## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read CONTRIBUTING.md and Coding_Convention.md
- [x] I have tested this fix or improvement against >=2 hosts and I couldn't spot a problem
