### PR TITLE
Declare jsonID

### DIFF
--- a/testssl.sh
+++ b/testssl.sh
@@ -2423,6 +2423,7 @@ s_client_options() {
 #
 service_detection() {
      local -i was_killed
+     local jsonID
 
      if [[ "$CLIENT_AUTH" != required ]]; then
           if ! "$HAS_TLS13" && "$TLS13_ONLY"; then
@@ -10258,6 +10259,7 @@ run_server_defaults() {
      local -a -i success
      local cn_nosni cn_sni sans_nosni sans_sni san tls_extensions extn client_auth_ca
      local using_sockets=true
+     local jsonID
 
      "$SSL_NATIVE" && using_sockets=false
 
@@ -17887,6 +17889,7 @@ run_crime() {
      local cve="CVE-2012-4929"
      local cwe="CWE-310"
      local hint=""
+     local jsonID
 
      # In a nutshell: don't offer TLS/SPDY compression. This tests for CRIME Vulnerability on HTTPS only,
      # not SPDY or ALPN (yet). Please note that it is an attack where you need client side control, so in
@@ -18160,6 +18163,7 @@ run_sweet32() {
      local ssl2_sweet=false
      local using_sockets=true
      local tls1_1_vulnerable=false
+     local jsonID="SWEET32"
 
      [[ $VULN_COUNT -le $VULN_THRESHLD ]] && outln && pr_headlineln " Testing for SWEET32 (Birthday Attacks on 64-bit Block Ciphers)       " && outln
      pr_bold " SWEET32"; out " (${cve// /, })    "
@@ -18206,7 +18210,7 @@ run_sweet32() {
           if [[ $(( nr_supported_ciphers + nr_ssl2_supported_ciphers )) -le $nr_cipher_minimal ]]; then
                pr_local_problem "Only ${nr_supported_ciphers}+${nr_ssl2_supported_ciphers} \"SWEET32 ciphers\" found in your $OPENSSL."
                outln " Test skipped"
-               fileout "SWEET32" "WARN" "Not tested, lack of local support ($((nr_supported_ciphers + nr_ssl2_supported_ciphers)) ciphers only)" "$cve" "$cwe" "$hint"
+               fileout "$jsonID" "WARN" "Not tested, lack of local support ($((nr_supported_ciphers + nr_ssl2_supported_ciphers)) ciphers only)" "$cve" "$cwe" "$hint"
                return 1
           fi
           for proto in -no_ssl2 -tls1_1 -tls1 -ssl3; do
@@ -18239,36 +18243,36 @@ run_sweet32() {
      fi
      if [[ $sclient_success -eq 0 ]] && "$ssl2_sweet" ; then
           pr_svrty_low "VULNERABLE"; out ", uses 64 bit block ciphers for SSLv2 and above"
-          fileout "SWEET32" "LOW" "uses 64 bit block ciphers for SSLv2 and above" "$cve" "$cwe" "$hint"
+          fileout "$jsonID" "LOW" "uses 64 bit block ciphers for SSLv2 and above" "$cve" "$cwe" "$hint"
           "$tls1_1_vulnerable" && set_grade_cap "C" "Uses 64 bit block ciphers with TLS 1.1 (vulnerable to SWEET32)"
      elif [[ $sclient_success -eq 0 ]]; then
           pr_svrty_low "VULNERABLE"; out ", uses 64 bit block ciphers"
-          fileout "SWEET32" "LOW" "uses 64 bit block ciphers" "$cve" "$cwe" "$hint"
+          fileout "$jsonID" "LOW" "uses 64 bit block ciphers" "$cve" "$cwe" "$hint"
           "$tls1_1_vulnerable" && set_grade_cap "C" "Uses 64 bit block ciphers with TLS 1.1 (vulnerable to SWEET32)"
      elif "$ssl2_sweet"; then
           pr_svrty_low "VULNERABLE"; out ", uses 64 bit block ciphers with SSLv2 only"
-          fileout "SWEET32" "LOW" "uses 64 bit block ciphers with SSLv2 only" "$cve" "$cwe" "$hint"
+          fileout "$jsonID" "LOW" "uses 64 bit block ciphers with SSLv2 only" "$cve" "$cwe" "$hint"
      else
           pr_svrty_best "not vulnerable (OK)";
           if "$using_sockets"; then
-               fileout "SWEET32" "OK" "not vulnerable" "$cve" "$cwe"
+               fileout "$jsonID" "OK" "not vulnerable" "$cve" "$cwe"
           else
                if [[ "$nr_supported_ciphers" -ge 38 ]]; then
                     # Likely only PSK/KRB5 ciphers are missing: display discrepancy but no warning
                     if "$HAS_SSL2"; then
                          out ", $nr_supported_ciphers/$nr_sweet32_ciphers (SSLv2: $nr_ssl2_sweet32_ciphers/$nr_ssl2_supported_ciphers) local ciphers"
-                         fileout "SWEET32" "OK" "not vulnerable ($nr_supported_ciphers of $nr_sweet32_ciphers (SSLv2: $nr_ssl2_sweet32_ciphers/$nr_ssl2_supported_ciphers)) local ciphers" "$cve" "$cwe"
+                         fileout "$jsonID" "OK" "not vulnerable ($nr_supported_ciphers of $nr_sweet32_ciphers (SSLv2: $nr_ssl2_sweet32_ciphers/$nr_ssl2_supported_ciphers)) local ciphers" "$cve" "$cwe"
                     else
                          out ", $nr_supported_ciphers/$nr_sweet32_ciphers local ciphers"
-                         fileout "SWEET32" "OK" "not vulnerable ($nr_supported_ciphers of $nr_sweet32_ciphers local ciphers" "$cve" "$cwe"
+                         fileout "$jsonID" "OK" "not vulnerable ($nr_supported_ciphers of $nr_sweet32_ciphers local ciphers" "$cve" "$cwe"
                     fi
                else
                     if "$HAS_SSL2"; then
                          pr_warning ", $nr_supported_ciphers/$nr_sweet32_ciphers (SSLv2: $nr_ssl2_sweet32_ciphers/$nr_ssl2_supported_ciphers) local ciphers"
-                         fileout "SWEET32" "WARN" "not vulnerable but ($nr_supported_ciphers of $nr_sweet32_ciphers (SSLv2: $nr_ssl2_sweet32_ciphers/$nr_ssl2_supported_ciphers)) local ciphers only" "$cve" "$cwe"
+                         fileout "$jsonID" "WARN" "not vulnerable but ($nr_supported_ciphers of $nr_sweet32_ciphers (SSLv2: $nr_ssl2_sweet32_ciphers/$nr_ssl2_supported_ciphers)) local ciphers only" "$cve" "$cwe"
                     else
                          pr_warning ", $nr_supported_ciphers/$nr_sweet32_ciphers local ciphers"
-                         fileout "SWEET32" "WARN" "not vulnerable but ($nr_supported_ciphers of $nr_sweet32_ciphers) local ciphers only" "$cve" "$cwe"
+                         fileout "$jsonID" "WARN" "not vulnerable but ($nr_supported_ciphers of $nr_sweet32_ciphers) local ciphers only" "$cve" "$cwe"
                     fi
                fi
           fi


### PR DESCRIPTION
As reported in #3128, there are a few instances in which `jsonID` is used, but is not declared as a `local` variable. This PR fixes that problem in this 3.2 branch.

In addition, for consistency, it changes `run_sweet32()` to use `$jsonID` rather than the hard coded string "SWEET32".

<!--

## Describe your changes
Please refer to an issue here or describe the change thoroughly in your PR and check the boxes which are applicable. 

This includes:
- Resolved or fixed issue: <-- ✍️ Add GitHub issue number in format `#0000` 
- A clear and concise summary of the change and which issue (if any) it fixes. Should also include relevant motivation and context.
- Please don't remove anything.
- You can tick the boxes later after you saved the PR or change the blank between the square brackets by an X or x

-->

## What is your pull request about?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [ ] Update of other files


## If it's a code change please check the boxes which are applicable
- [x] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [x] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [x] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order of last name) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ ] I found a bug / an improvement using LLM version: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`
- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, JetBrains Junie, VS Code plugin <NAME> etc.]`
    - LLMs and versions: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`

