### PR TITLE
Provide short unit test for TLS 1.3 only host / PoC for "openssl s_server" 

### DIFF
--- a/.github/workflows/cgroups_test.yml
+++ b/.github/workflows/cgroups_test.yml
@@ -14,7 +14,7 @@ jobs:
           openssl req -x509 -newkey rsa:2048 -keyout /tmp/k.pem -out /tmp/c.pem \
             -days 42 -nodes -subj "/CN=localhost" \
             -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
-          openssl s_server -accept 127.0.0.1:1443 -cert /tmp/c.pem -key /tmp/k.pem \
+          RUNNER_TRACKING_ID="" && openssl s_server -accept 127.0.0.1:1443 -cert /tmp/c.pem -key /tmp/k.pem \
             -tls1_3 -naccept 4242 >/tmp/srv.log 2>&1 &
           SPID=$!
           sleep 2

--- a/.github/workflows/cgroups_test.yml
+++ b/.github/workflows/cgroups_test.yml
@@ -1,0 +1,32 @@
+---
+name: cgroups test
+on: [pull_request]
+permissions:
+  contents: read
+
+jobs:
+  repro:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Bare s_server, no perl, no testssl
+        run: |
+          set -x
+          openssl req -x509 -newkey rsa:2048 -keyout /tmp/k.pem -out /tmp/c.pem \
+            -days 42 -nodes -subj "/CN=localhost" \
+            -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
+          openssl s_server -accept 127.0.0.1:1443 -cert /tmp/c.pem -key /tmp/k.pem \
+            -tls1_3 -naccept 4242 >/tmp/srv.log 2>&1 &
+          SPID=$!
+          sleep 2
+          echo "alive-before: $(kill -0 $SPID 2>/dev/null && echo yes || echo no)"
+          # the 'probe': connect and immediately close, exactly like the perl probe
+          timeout 2 bash -c 'echo > /dev/tcp/127.0.0.1/1443' 2>/dev/null
+          echo "probe-exit: $?"
+          sleep 2
+          echo "alive-after:  $(kill -0 $SPID 2>/dev/null && echo yes || echo no)"
+          echo '--- srv.log ---'; cat /tmp/srv.log
+          echo '--- cgroup ---'; cat /proc/$SPID/cgroup 2>/dev/null || echo "(process gone)"
+          echo '--- seccomp ---'; grep -E 'Seccomp|NoNewPrivs' /proc/$SPID/status 2>/dev/null || echo "(process gone)"
+          echo '--- limits ---'; cat /proc/$SPID/limits 2>/dev/null || echo "(process gone)"
+          kill -9 $SPID 2>/dev/null
+

--- a/.github/workflows/perl-quality.yml
+++ b/.github/workflows/perl-quality.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - 't/**'
-      - 'cpanfile'
-      - '.perlcritic'
       - '.github/workflows/perl-quality.yml'
 
 permissions:

--- a/.github/workflows/perl-quality.yml
+++ b/.github/workflows/perl-quality.yml
@@ -25,7 +25,7 @@ jobs:
         run: cpanm --notest Perl::Critic Perl::Tidy CPAN::Audit
       - name: Install dev modules
         # add all perl modules from other modules tool, otherwise the next run fails
-        run: cpanm --notest Data::Dumper IPC::Run3 JSON Test::More Text::Diff
+        run: cpanm --notest Data::Dumper IPC::Run3 IO::Socket::INET JSON Test::More Text::Diff File::Temp File::Basename
 
       - name: 'Syntax check #1 w Perl::Tidy'
         run: |

--- a/t/04_gha_does_thatwork.t
+++ b/t/04_gha_does_thatwork.t
@@ -1,0 +1,166 @@
+#!/usr/bin/env perl
+#
+# tls_server_client_test.pl
+#
+# Starts `openssl s_server` in the background (safe under GitHub Actions:
+# strips RUNNER_TRACKING_ID so the runner's cleanup sweep won't reap it,
+# and redirects stdin from /dev/null with -ign_eof so s_server doesn't
+# quit after the first connection), waits until it's actually accepting
+# connections, then drives one or more `openssl s_client` checks against
+# it. Server is always killed on the way out, success or failure.
+#
+# Host, port, and the self-signed cert/key are all generated/fixed here
+# rather than taken from the command line.
+#
+# Usage:
+#   ./tls_server_client_test.pl
+#
+use strict;
+use warnings;
+use IPC::Run3;
+use File::Temp qw(tempdir);
+
+use constant {
+    HOST => '127.0.0.1',
+    PORT => 4433,
+};
+
+my $LOG = 's_server.' . PORT . '.log';
+
+# tempdir with CLEANUP => 1 removes itself (and the cert/key inside it)
+# when the script exits, normally or via die/signal.
+my $CERT_DIR = tempdir(CLEANUP => 1);
+my $CERT     = "$CERT_DIR/cert.pem";
+my $KEY      = "$CERT_DIR/key.pem";
+
+generate_cert($CERT, $KEY);
+print "generated self-signed cert/key in $CERT_DIR\n";
+
+# ---------------------------------------------------------------------
+# Start the server
+# ---------------------------------------------------------------------
+my $server_pid = start_server(HOST, PORT, $CERT, $KEY, $LOG);
+print "started s_server pid=$server_pid on " . HOST . ":" . PORT . " (log: $LOG)\n";
+
+# Make sure we clean up on normal exit *and* on die()/signal.
+my $cleaned_up = 0;
+local $SIG{__DIE__} = sub { cleanup($server_pid) unless $cleaned_up; };
+local $SIG{INT}     = sub { cleanup($server_pid) unless $cleaned_up; exit 1; };
+local $SIG{TERM}    = sub { cleanup($server_pid) unless $cleaned_up; exit 1; };
+
+my $exit_code = 0;
+eval {
+    wait_for_ready(HOST, PORT, 20, 0.5);
+    run_client_checks(HOST, PORT);
+    1;
+} or do {
+    warn "test failed: $@";
+    $exit_code = 1;
+};
+
+cleanup($server_pid);
+exit $exit_code;
+
+# ---------------------------------------------------------------------
+
+sub generate_cert {
+    my ($cert, $key) = @_;
+
+    my ($out, $err);
+    run3(
+        ['openssl', 'req', '-x509', '-newkey', 'rsa:2048', '-nodes',
+         '-keyout', $key, '-out', $cert,
+         '-days', '1',
+         '-subj', '/CN=localhost',
+         '-addext', 'subjectAltName=IP:' . HOST],
+        \undef, \$out, \$err,
+    );
+
+    die "cert generation failed:\n$err\n" if $? != 0;
+}
+
+sub start_server {
+    my ($host, $port, $cert, $key, $log) = @_;
+
+    my $pid = fork();
+    die "fork failed: $!" unless defined $pid;
+
+    if ($pid == 0) {
+        # --- child: becomes openssl s_server ---
+
+        # Strip the runner's tracking env var so the Actions runner's
+        # process-cleanup sweep (which greps for it) doesn't kill us
+        # the moment this step/job ends.
+        delete local $ENV{RUNNER_TRACKING_ID};
+
+        # Detach stdin from whatever the parent had (important: s_server
+        # treats stdin EOF as "quit after this connection" unless told
+        # otherwise). -ign_eof is a second belt-and-suspenders layer.
+        open(STDIN,  '<', '/dev/null') or die "reopen STDIN: $!";
+        open(STDOUT, '>', $log)        or die "reopen STDOUT: $!";
+        open(STDERR, '>&STDOUT')       or die "reopen STDERR: $!";
+
+        exec('openssl', 's_server',
+             '-accept', "$host:$port",
+             '-cert',   $cert,
+             '-key',    $key,
+             '-ign_eof',
+             '-quiet');
+        # exec only returns on failure
+        die "exec openssl s_server failed: $!";
+    }
+
+    return $pid;
+}
+
+sub wait_for_ready {
+    my ($host, $port, $tries, $delay) = @_;
+
+    for my $i (1 .. $tries) {
+        my ($out, $err);
+        # Empty stdin: just probe the handshake, don't send app data.
+        run3(
+            ['openssl', 's_client', '-connect', "$host:$port"],
+            \'', \$out, \$err,
+        );
+        return 1 if $? == 0;
+        select(undef, undef, undef, $delay); # fractional sleep
+    }
+
+    die "server on $host:$port never became ready after $tries attempts\n";
+}
+
+sub run_client_checks {
+    my ($host, $port) = @_;
+
+    # Replace this with your real test(s). Shown here: a basic connect
+    # that feeds a line of data through and checks openssl's exit code
+    # plus captured output. Swap in Test::More ok()/is() calls as needed.
+    my ($out, $err);
+    run3(
+        ['testssl.sh', '-p', "$host:$port"],
+        \"", \$out, \$err,
+    );
+
+    die "s_client exited non-zero: $?\nstderr:\n$err\n" if $? != 0;
+
+    print "client check ok, output:\n$out\n";
+}
+
+sub cleanup {
+    my ($pid) = @_;
+    return unless $pid;
+    $cleaned_up = 1;
+
+    if (kill(0, $pid)) {          # still alive?
+        kill('TERM', $pid);
+        # give it a moment, then force it
+        for (1 .. 10) {
+            last unless kill(0, $pid);
+            select(undef, undef, undef, 0.2);
+        }
+        kill('KILL', $pid) if kill(0, $pid);
+    }
+    waitpid($pid, 0);
+    print "cleaned up s_server pid=$pid\n";
+}

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -30,13 +30,13 @@ OPENSSL=/usr/bin/openssl
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" 2>&1
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" >/dev/null 2>&1
 fi
 
 # Start OpenSSL server
 echo "Starting server on port $PORT..."
-# $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
-$OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3
+# $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE" -naccept 4242
+$OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
 HEREDOC
 
 
@@ -50,9 +50,11 @@ chmod 0755, $server_script;
 # Start the server in the background using fork/exec
 my $pid = fork();
 if ($pid == 0) {
-   # Exec the script in a child process
-   exec($server_script);
-   exit 0; # Should not reach here
+    chdir($temp_dir)                       or exit 1;
+    open(STDOUT, '>', "$temp_dir/server.log") or exit 1;
+    open(STDERR, '>&', STDOUT)               or exit 1;
+    exec($server_script);
+    exit 1;
 }
 elsif ($pid > 0) {
    # Parent process: Wait for server to be ready
@@ -90,10 +92,19 @@ elsif ($pid > 0) {
        # Check if TLS 1.2 is NOT found
        unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
 
-       diag("Test output:\n$testssl_output");
-   } else {
-       diag("Server failed to start");
-   }
+       # diag("Test output:\n$testssl_output");
+
+  } else {
+    my $log = '';
+    if (open my $lfh, '<', "$temp_dir/server.log") {
+        local $/;            # slurp mode
+        $log = <$lfh> // '';
+        close $lfh;
+    }
+    diag("Server failed to start. Log:\n$log");
+}
+
+
 
    # Cleanup: Kill the server process
    kill 9, $pid;

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# As the name indicates: Check for TLS 1.3 only hosts. It just run the protocol section, there
+# As the name indicates: Check for TLS 1.3 only hosts. It just runs the protocol section, there
 # it checks for TLS 1.2 (disabled) and TLS 1.3 (enabled)
 
 use strict;
@@ -14,15 +14,25 @@ my $port = 1443;
 my $temp_dir = tempdir(CLEANUP => 1);
 my $server_script = "$temp_dir/start_server.sh";
 
-# 1. The Shell Script as HEREDOC
+
+# Shell script as HEREDOC - aim is reusability
 my $shell_code = <<'HEREDOC';
 #!/bin/bash
 # Configuration
 PORT=1443
+IP=127.0.0.1
 CERT="server.pem"
 KEY="server.key"
 # This OpenSSL version will support TLS 1.3
 OPENSSL=/usr/bin/openssl
+
+if [[ $(openssl version) =~ LibreSSL ]]; then               # MacOS. LibreSSL doesn't know "-naccept"
+     if [[ -x /opt/homebrew/bin/openssl.NOPE ]]; then
+          OPENSSL=/opt/homebrew/bin/openssl.NOPE            # We hid that during GHA CI checks
+     elif [[ -x /opt/homebrew/bin/openssl ]]; then
+          OPENSSL=/opt/homebrew/bin/openssl                 # If you intend this to run
+     fi
+fi
 
 # Force a specific TLS 1.3 cipher suite when needed
 # CIPHER_SUITE="TLS_AES_256_GCM_SHA384"
@@ -35,8 +45,9 @@ fi
 
 # Start OpenSSL server
 echo "Starting server on port $PORT..."
-# $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE" -naccept 4242
-$OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
+# $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE" -naccept 4242
+$OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
+
 HEREDOC
 
 
@@ -62,10 +73,11 @@ elsif ($pid > 0) {
    # Wait for the server to be listening on the port
    my $socket;
    my $ready = 0;
+   my $listenip = '127.0.0.1';
 
    for my $i (1..30) {
        $socket = IO::Socket::INET->new(
-           PeerAddr => 'localhost',
+           PeerAddr => $listenip,
            PeerPort => $port,
            Proto    => 'tcp',
            Timeout  => 2,
@@ -79,12 +91,12 @@ elsif ($pid > 0) {
        sleep 1;
    }
 
-   ok($ready, "Server is listening on port $port");
+   ok($ready, "Server is listening on $listenip:$port");
 
    if ($ready) {
        # Run testssl.sh, capture both stdout and stderr.
        # We're using the OpenSSL version testssl.sh picks up
-       my $testssl_output = `./testssl.sh --protocols localhost:$port 2>&1`;
+       my $testssl_output = `./testssl.sh --protocols $listenip:$port 2>&1`;
 
        # Check if TLS 1.3 is found
        like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
@@ -92,20 +104,15 @@ elsif ($pid > 0) {
        # Check if TLS 1.2 is NOT found
        unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
 
-       # diag("Test output:\n$testssl_output");
-
-  } else {
-    my $log = '';
-    if (open my $lfh, '<', "$temp_dir/server.log") {
-        local $/;            # slurp mode
-        $log = <$lfh> // '';
-        close $lfh;
-    }
-    diag("Server failed to start. Log:\n$log");
-}
-
-
-
+   } else {
+     my $log = '';
+     if (open my $lfh, '<', "$temp_dir/server.log") {
+          local $/;            # slurp mode
+          $log = <$lfh> // '';
+          close $lfh;
+     }
+     diag("Server failed to start. Log:\n$log");
+   }
    # Cleanup: Kill the server process
    kill 9, $pid;
    waitpid($pid, 0);
@@ -116,4 +123,4 @@ else {
 
 done_testing();
 
-#  vim:ts=5:sw=5:expandtab
+# vim:ts=5:sw=5:expandtab

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -1,0 +1,101 @@
+#!/usr/bin/env perl
+
+# As the name indicates: Check for TLS 1.3 only hosts
+
+use strict;
+use warnings;
+use Test::More;
+use IPC::Run qw( start timeout );
+use File::Temp qw( tempdir );
+use File::Basename;
+use File::Path qw( remove_tree );
+use File::Copy;
+
+my $port = 1443;
+my $server_script;
+my $temp_dir;
+
+BEGIN {
+    $temp_dir = tempdir(CLEANUP => 1);
+    # Path to the testssl.sh script (assuming we are in the project root)
+    $server_script = "$temp_dir/start_server.sh";
+}
+
+# 2. The Shell Script (HEREDOC)
+# We adapt your snippet slightly to ensure it runs deterministically as a test.
+my $shell_code = <<'HEREDOC';
+#!/bin/bash
+# Configuration
+PORT=1443
+CERT="server.pem"
+KEY="server.key"
+PROTOCOL="tls1_3"
+DAYS=365
+OPENSSL=/usr/bin/openssl
+
+# For a test, we force a specific TLS 1.3 cipher suite to ensure the server starts reliably
+# instead of relying on defaults or user input.
+# CIPHER_SUITE="TLS_AES_256_GCM_SHA384"
+
+# Generate self-signed cert and key if they don't exist
+if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
+    echo "Generating self-signed certificate and key..."
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days "$DAYS" -nodes -subj "/CN=localhost"
+fi
+
+# Start OpenSSL server
+# Note: We use -tls1_3 to enable TLS 1.3.
+echo "Starting server on port $PORT..."
+# $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
+$OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3
+HEREDOC
+
+# 3. Setup: Write and execute the script
+subtest 'TLS 1.3 Only Server Setup', sub {
+    plan skip_all => "IPC::Run not available" unless eval { require IPC::Run; 1 };
+
+    # Write the script to the temp directory
+    open(my $fh, '>', $server_script) or die "Cannot write script: $!";
+    print $fh $shell_code;
+    close($fh);
+
+    chmod 0755, $server_script;
+
+    # Start the server in the background
+    my $server = IPC::Run::start([ $server_script ]);
+
+    # Wait for the server to be listening on the port
+    my $ready = 0;
+    for my $i (1..20) {
+        if (system("nc -z localhost $port") == 0) {
+            $ready = 1;
+            last;
+        }
+        sleep 1;
+    }
+
+    ok($ready, "Server is listening on port $port");
+
+    if (!$ready) {
+        diag("Server failed to start");
+        $server->finish;
+        return;
+    }
+
+    # Run testssl.sh
+    my $testssl_output = `./testssl.sh --protocols localhost:$port 2>&1`;
+
+    # Verify
+    like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
+
+    # Check if TLS 1.2 is NOT found (since we only enabled tls1_3)
+    # We look for "TLS 1.2" but try to exclude it if it's in a "not supported" section, 
+    # but usually testssl prints "NOT offered" or similar.
+    # A safer check for "TLS 1.3 ONLY" is to ensure 1.2 is explicitly rejected.
+    unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
+
+    # Cleanup the server process
+    $server->finish;
+};
+
+done_testing();

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -1,58 +1,47 @@
 #!/usr/bin/env perl
 
-# As the name indicates: Check for TLS 1.3 only hosts
+# As the name indicates: Check for TLS 1.3 only hosts. It just run the protocol section, there
+# it checks for TLS 1.2 (disabled) and TLS 1.3 (enabled)
 
 use strict;
 use warnings;
 use Test::More;
-use IPC::Run qw( start timeout );
+use IO::Socket::INET;
 use File::Temp qw( tempdir );
 use File::Basename;
-use File::Path qw( remove_tree );
-use File::Copy;
 
 my $port = 1443;
-my $server_script;
-my $temp_dir;
+my $temp_dir = tempdir(CLEANUP => 1);
+my $server_script = "$temp_dir/start_server.sh";
 
-BEGIN {
-    $temp_dir = tempdir(CLEANUP => 1);
-    # Path to the testssl.sh script (assuming we are in the project root)
-    $server_script = "$temp_dir/start_server.sh";
-}
-
-# 2. The Shell Script (HEREDOC)
-# We adapt your snippet slightly to ensure it runs deterministically as a test.
+# 1. The Shell Script as HEREDOC
 my $shell_code = <<'HEREDOC';
 #!/bin/bash
 # Configuration
 PORT=1443
 CERT="server.pem"
 KEY="server.key"
-PROTOCOL="tls1_3"
-DAYS=365
+# This OpenSSL version will support TLS 1.3
 OPENSSL=/usr/bin/openssl
 
-# For a test, we force a specific TLS 1.3 cipher suite to ensure the server starts reliably
-# instead of relying on defaults or user input.
+# Force a specific TLS 1.3 cipher suite when needed
 # CIPHER_SUITE="TLS_AES_256_GCM_SHA384"
 
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days "$DAYS" -nodes -subj "/CN=localhost"
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost"
 fi
 
 # Start OpenSSL server
-# Note: We use -tls1_3 to enable TLS 1.3.
 echo "Starting server on port $PORT..."
 # $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
 $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3
 HEREDOC
 
-# 3. Setup: Write and execute the script
+# Write and execute the script
 subtest 'TLS 1.3 Only Server Setup', sub {
-    plan skip_all => "IPC::Run not available" unless eval { require IPC::Run; 1 };
+    plan skip_all => "File::Temp not available" unless eval { require File::Temp; 1 };
 
     # Write the script to the temp directory
     open(my $fh, '>', $server_script) or die "Cannot write script: $!";
@@ -61,41 +50,62 @@ subtest 'TLS 1.3 Only Server Setup', sub {
 
     chmod 0755, $server_script;
 
-    # Start the server in the background
-    my $server = IPC::Run::start([ $server_script ]);
+    # Start the server in the background using fork/exec
+    my $pid = fork();
+    if ($pid == 0) {
+        # Exec the script in a child process
+        exec($server_script);
+        exit 0; # Should not reach here
+    }
+    elsif ($pid > 0) {
+        # Parent process: Wait for server to be ready
 
-    # Wait for the server to be listening on the port
-    my $ready = 0;
-    for my $i (1..20) {
-        if (system("nc -z localhost $port") == 0) {
-            $ready = 1;
-            last;
+        # Wait for the server to be listening on the port
+        my $socket;
+        my $ready = 0;
+
+        for my $i (1..30) {
+            $socket = IO::Socket::INET->new(
+                PeerAddr => 'localhost',
+                PeerPort => $port,
+                Proto    => 'tcp',
+                Timeout  => 2,
+            );
+
+            if ($socket) {
+                $ready = 1;
+                last;
+            }
+            sleep 1;
         }
-        sleep 1;
+
+        ok($ready, "Server is listening on port $port");
+
+        if ($ready) {
+            # Run testssl.sh
+            # capture both stdout and stderr
+            my $testssl_output = `./testssl.sh --protocols localhost:$port 2>&1`;
+
+            # Check if TLS 1.3 is found
+            like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
+
+            # Check if TLS 1.2 is NOT found
+            unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
+
+            diag("Test output:\n$testssl_output");
+        } else {
+            diag("Server failed to start");
+        }
+
+        # Cleanup: Kill the server process
+        kill 9, $pid;
+        waitpid($pid, 0);
     }
-
-    ok($ready, "Server is listening on port $port");
-
-    if (!$ready) {
-        diag("Server failed to start");
-        $server->finish;
-        return;
+    else {
+        die "Fork failed: $!";
     }
-
-    # Run testssl.sh
-    my $testssl_output = `./testssl.sh --protocols localhost:$port 2>&1`;
-
-    # Verify
-    like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
-
-    # Check if TLS 1.2 is NOT found (since we only enabled tls1_3)
-    # We look for "TLS 1.2" but try to exclude it if it's in a "not supported" section, 
-    # but usually testssl prints "NOT offered" or similar.
-    # A safer check for "TLS 1.3 ONLY" is to ensure 1.2 is explicitly rejected.
-    unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
-
-    # Cleanup the server process
-    $server->finish;
 };
 
 done_testing();
+
+#  vim:ts=5:sw=5:expandtab

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -30,7 +30,7 @@ OPENSSL=/usr/bin/openssl
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost"
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" 2>&1
 fi
 
 # Start OpenSSL server
@@ -39,72 +39,69 @@ echo "Starting server on port $PORT..."
 $OPENSSL s_server -accept "$PORT" -cert "$CERT" -key "$KEY" -tls1_3
 HEREDOC
 
-# Write and execute the script
-subtest 'TLS 1.3 Only Server Setup', sub {
-    plan skip_all => "File::Temp not available" unless eval { require File::Temp; 1 };
 
-    # Write the script to the temp directory
-    open(my $fh, '>', $server_script) or die "Cannot write script: $!";
-    print $fh $shell_code;
-    close($fh);
+# Write the script to the temp directory
+open(my $fh, '>', $server_script) or die "Cannot write script: $!";
+print $fh $shell_code;
+close($fh);
 
-    chmod 0755, $server_script;
+chmod 0755, $server_script;
 
-    # Start the server in the background using fork/exec
-    my $pid = fork();
-    if ($pid == 0) {
-        # Exec the script in a child process
-        exec($server_script);
-        exit 0; # Should not reach here
-    }
-    elsif ($pid > 0) {
-        # Parent process: Wait for server to be ready
+# Start the server in the background using fork/exec
+my $pid = fork();
+if ($pid == 0) {
+   # Exec the script in a child process
+   exec($server_script);
+   exit 0; # Should not reach here
+}
+elsif ($pid > 0) {
+   # Parent process: Wait for server to be ready
 
-        # Wait for the server to be listening on the port
-        my $socket;
-        my $ready = 0;
+   # Wait for the server to be listening on the port
+   my $socket;
+   my $ready = 0;
 
-        for my $i (1..30) {
-            $socket = IO::Socket::INET->new(
-                PeerAddr => 'localhost',
-                PeerPort => $port,
-                Proto    => 'tcp',
-                Timeout  => 2,
-            );
+   for my $i (1..30) {
+       $socket = IO::Socket::INET->new(
+           PeerAddr => 'localhost',
+           PeerPort => $port,
+           Proto    => 'tcp',
+           Timeout  => 2,
+       );
 
-            if ($socket) {
-                $ready = 1;
-                last;
-            }
-            sleep 1;
-        }
+       if ($socket) {
+           $ready = 1;
+           close($socket);
+           last;
+       }
+       sleep 1;
+   }
 
-        ok($ready, "Server is listening on port $port");
+   ok($ready, "Server is listening on port $port");
 
-        if ($ready) {
-            # Run testssl.sh
-            # capture both stdout and stderr
-            my $testssl_output = `./testssl.sh --protocols localhost:$port 2>&1`;
+   if ($ready) {
+       # Run testssl.sh, capture both stdout and stderr.
+       # We're using the OpenSSL version testssl.sh picks up
+       my $testssl_output = `./testssl.sh --protocols localhost:$port 2>&1`;
 
-            # Check if TLS 1.3 is found
-            like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
+       # Check if TLS 1.3 is found
+       like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
 
-            # Check if TLS 1.2 is NOT found
-            unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
+       # Check if TLS 1.2 is NOT found
+       unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
 
-            diag("Test output:\n$testssl_output");
-        } else {
-            diag("Server failed to start");
-        }
+       diag("Test output:\n$testssl_output");
+   } else {
+       diag("Server failed to start");
+   }
 
-        # Cleanup: Kill the server process
-        kill 9, $pid;
-        waitpid($pid, 0);
-    }
-    else {
-        die "Fork failed: $!";
-    }
-};
+   # Cleanup: Kill the server process
+   kill 9, $pid;
+   waitpid($pid, 0);
+}
+else {
+   die "Fork failed: $!";
+}
 
 done_testing();
 

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -46,7 +46,7 @@ KEY="server.key"
 # This OpenSSL version will support TLS 1.3
 OPENSSL=/usr/bin/openssl
 
-if [[ $(openssl version) =~ LibreSSL ]]; then               # MacOS. LibreSSL doesn't know "-naccept"
+if [[ $($OPENSSL version) =~ LibreSSL ]]; then              # MacOS. LibreSSL doesn't know "-naccept"
      if [[ -x /opt/homebrew/bin/openssl.NOPE ]]; then
           OPENSSL=/opt/homebrew/bin/openssl.NOPE            # We hid that during GHA CI checks
      elif [[ -x /opt/homebrew/bin/openssl ]]; then

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -66,7 +66,7 @@ fi
 # Start OpenSSL server
 echo "Starting server on port $PORT..."
 # $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
-RUNNER_TRACKING_ID="" && $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
+env -u RUNNER_TRACKING_ID $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ign_eof 2>&1
 
 HEREDOC
 

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -84,12 +84,12 @@ if ($pid == 0) {
     chdir($temp_dir)                       or exit 1;
     open(STDOUT, '>', "$temp_dir/server.log") or exit 1;
     open(STDERR, '>&', STDOUT)               or exit 1;
+    pipe(my $r, my $w) or exit 1;            # <-- new
+    open(STDIN,  '<&', $r) or exit 1;        # <-- new
     exec($server_script);
     exit 1;
 }
 elsif ($pid > 0) {
-   # Parent process: Wait for server to be ready
-
    # Wait for the server to be listening on the port
    my $socket;
    my $ready = 0;
@@ -113,24 +113,21 @@ elsif ($pid > 0) {
 
    ok($ready, "Server is listening on $listenip:$port");
 
-     # ---- DEBUG stuff, taken right before testssl runs ----
-       my $reaped = waitpid($pid, WNOHANG);          # 0 => still running
-       my $state  = ($reaped == 0) ? 'ALIVE' : "DEAD (waitpid=$reaped)";
-       diag("DEBUG pre-testssl: pid=$pid state=$state");
-
-       my $listening = port_listening($listenip, $port);
-       diag("DEBUG pre-testssl: $listenip:$port LISTEN=" . ($listening // 'n/a'));
+   # ---- DEBUG stuff, taken right before testssl runs ----
+   my $reaped = waitpid($pid, WNOHANG);          # 0 => still running
+   my $state  = ($reaped == 0) ? 'ALIVE' : "DEAD (waitpid=$reaped)";
+   diag("DEBUG pre-testssl: pid=$pid state=$state");
 
    if  ( $os eq "linux" ){
+      my $listening = port_listening($listenip, $port);
+      diag("DEBUG pre-testssl: $listenip:$port LISTEN=" . ($listening // 'n/a'));
       diag("DEBUG netns: " . (`readlink /proc/self/ns/net 2>&1`));
       diag("DEBUG cgroup: " . (`cat /proc/self/cgroup 2>&1`));
       diag("DEBUG ss: "     . (`ss -ltnp 2>&1 | grep ":$port " || echo "(no listener)"`));
+
+      diag("DEBUG direct bash connect: " .
+        (`timeout 2 bash -c "echo > /dev/tcp/$listenip/$port" 2>&1 && echo OK || echo REFUSED`));
    }
-
-   diag("DEBUG direct bash connect: " .
-     (`timeout 2 bash -c "echo > /dev/tcp/$listenip/$port" 2>&1 && echo OK || echo REFUSED`));
-
-
    sleep (2);
 
    my $log_pre = '';
@@ -156,7 +153,7 @@ elsif ($pid > 0) {
    diag("Server Log:\n$log");
 }
 
-# Cleanup: Kill the server process. When run locally this is needed
+# Cleanup: Kill the server process. When running locally this is needed
 my $openssl_pid = `lsof -i -Pn | grep \$USER | grep openssl | awk '{ print \$2 }'`;
 kill 9, $openssl_pid;
 waitpid($openssl_pid, 0);

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -10,10 +10,30 @@ use IO::Socket::INET;
 use File::Temp qw( tempdir );
 use File::Basename;
 
+use POSIX qw(WNOHANG);
+
+
 my $port = 1443;
 my $temp_dir = tempdir(CLEANUP => 1);
 my $server_script = "$temp_dir/start_server.sh";
+my $os="$^O";
 
+# Non-intrusive check: is $ip:$port in LISTEN state in our network namespace?
+# Reads /proc/net/tcp, so it does NOT consume a connection (unlike a probe).
+sub port_listening {
+    my ($ip, $port) = @_;
+    return undef unless -r '/proc/net/tcp';
+    my $hex_port = sprintf("%04X", $port);
+    my $hex_ip   = join '', map { sprintf("%02X", $_) } reverse split(/\./, $ip);
+    open my $fh, '<', '/proc/net/tcp' or return undef;
+    while (<$fh>) {
+        next if /^sl/;
+        my @f = split;
+        return 1 if $f[1] eq "$hex_ip:$hex_port" && $f[3] eq '0A';   # 0A == LISTEN
+    }
+    close $fh;
+    return 0;
+}
 
 # Shell script as HEREDOC - aim is reusability
 my $shell_code = <<'HEREDOC';
@@ -40,7 +60,7 @@ fi
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" >/dev/null 2>&1
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
 fi
 
 # Start OpenSSL server
@@ -88,31 +108,54 @@ elsif ($pid > 0) {
            close($socket);
            last;
        }
-       sleep 1;
    }
 
    ok($ready, "Server is listening on $listenip:$port");
 
    if ($ready) {
-       # Run testssl.sh, capture both stdout and stderr.
-       # We're using the OpenSSL version testssl.sh picks up
+       sleep(2);
+
+       # ---- DEBUG stuff, taken right before testssl runs ----
+       my $reaped = waitpid($pid, WNOHANG);          # 0 => still running
+       my $state  = ($reaped == 0) ? 'ALIVE' : "DEAD (waitpid=$reaped)";
+       diag("DEBUG pre-testssl: pid=$pid state=$state");
+
+       my $listening = port_listening($listenip, $port);
+       diag("DEBUG pre-testssl: $listenip:$port LISTEN=" . ($listening // 'n/a'));
+
+if  ( $os eq "linux" ){
+diag("DEBUG netns: " . (`readlink /proc/self/ns/net 2>&1`));
+diag("DEBUG cgroup: " . (`cat /proc/self/cgroup 2>&1`));
+diag("DEBUG ss: "     . (`ss -ltnp 2>&1 | grep ":$port " || echo "(no listener)"`));
+}
+
+diag("DEBUG direct bash connect: " .
+     (`timeout 2 bash -c "echo > /dev/tcp/$listenip/$port" 2>&1 && echo OK || echo REFUSED`));
+
+
+       my $log_pre = '';
+       if (open my $lfh, '<', "$temp_dir/server.log") {
+           local $/;
+           $log_pre = <$lfh> // '';
+           close $lfh;
+       }
+       diag("DEBUG pre-testssl server.log:\n$log_pre");
+       # ---- end DEBUG ----
+
        my $testssl_output = `./testssl.sh --protocols $listenip:$port 2>&1`;
 
-       # Check if TLS 1.3 is found
-       like($testssl_output, qr/TLS 1\.3/, "TLS 1.3 is supported");
-
-       # Check if TLS 1.2 is NOT found
+       like($testssl_output,   qr/TLS 1\.3/,        "TLS 1.3 is supported");
        unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
 
-   } else {
-     my $log = '';
-     if (open my $lfh, '<', "$temp_dir/server.log") {
-          local $/;            # slurp mode
-          $log = <$lfh> // '';
-          close $lfh;
-     }
-     diag("Server failed to start. Log:\n$log");
+       my $log = '';
+       if (open my $lfh, '<', "$temp_dir/server.log") {
+           local $/;
+           $log = <$lfh> // '';
+           close $lfh;
+       }
+       diag("Server Log:\n$log");
    }
+
    # Cleanup: Kill the server process
    kill 9, $pid;
    waitpid($pid, 0);
@@ -120,6 +163,9 @@ elsif ($pid > 0) {
 else {
    die "Fork failed: $!";
 }
+
+
+
 
 done_testing();
 

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -66,7 +66,7 @@ fi
 # Start OpenSSL server
 echo "Starting server on port $PORT..."
 # $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
-$OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
+RUNNER_TRACKING_ID="" && $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
 
 HEREDOC
 

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -60,7 +60,7 @@ fi
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null 2>&1
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null
 fi
 
 # Start OpenSSL server
@@ -108,6 +108,7 @@ elsif ($pid > 0) {
            close($socket);
            last;
        }
+       sleep 1;
    }
 
    ok($ready, "Server is listening on $listenip:$port");

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -60,13 +60,13 @@ fi
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null
+    $OPENSSL req -quiet -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null
 fi
 
 # Start OpenSSL server
 echo "Starting server on port $PORT..."
-# $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE" -naccept 4242
-$OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
+# $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
+$OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3
 
 HEREDOC
 
@@ -108,15 +108,12 @@ elsif ($pid > 0) {
            close($socket);
            last;
        }
-       sleep 1;
+       sleep (1);
    }
 
    ok($ready, "Server is listening on $listenip:$port");
 
-   if ($ready) {
-       sleep(2);
-
-       # ---- DEBUG stuff, taken right before testssl runs ----
+     # ---- DEBUG stuff, taken right before testssl runs ----
        my $reaped = waitpid($pid, WNOHANG);          # 0 => still running
        my $state  = ($reaped == 0) ? 'ALIVE' : "DEAD (waitpid=$reaped)";
        diag("DEBUG pre-testssl: pid=$pid state=$state");
@@ -124,49 +121,45 @@ elsif ($pid > 0) {
        my $listening = port_listening($listenip, $port);
        diag("DEBUG pre-testssl: $listenip:$port LISTEN=" . ($listening // 'n/a'));
 
-if  ( $os eq "linux" ){
-diag("DEBUG netns: " . (`readlink /proc/self/ns/net 2>&1`));
-diag("DEBUG cgroup: " . (`cat /proc/self/cgroup 2>&1`));
-diag("DEBUG ss: "     . (`ss -ltnp 2>&1 | grep ":$port " || echo "(no listener)"`));
-}
+   if  ( $os eq "linux" ){
+      diag("DEBUG netns: " . (`readlink /proc/self/ns/net 2>&1`));
+      diag("DEBUG cgroup: " . (`cat /proc/self/cgroup 2>&1`));
+      diag("DEBUG ss: "     . (`ss -ltnp 2>&1 | grep ":$port " || echo "(no listener)"`));
+   }
 
-diag("DEBUG direct bash connect: " .
+   diag("DEBUG direct bash connect: " .
      (`timeout 2 bash -c "echo > /dev/tcp/$listenip/$port" 2>&1 && echo OK || echo REFUSED`));
 
 
-       my $log_pre = '';
-       if (open my $lfh, '<', "$temp_dir/server.log") {
-           local $/;
-           $log_pre = <$lfh> // '';
-           close $lfh;
-       }
-       diag("DEBUG pre-testssl server.log:\n$log_pre");
-       # ---- end DEBUG ----
+   sleep (2);
 
-       my $testssl_output = `./testssl.sh --protocols $listenip:$port 2>&1`;
-
-       like($testssl_output,   qr/TLS 1\.3/,        "TLS 1.3 is supported");
-       unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
-
-       my $log = '';
-       if (open my $lfh, '<', "$temp_dir/server.log") {
-           local $/;
-           $log = <$lfh> // '';
-           close $lfh;
-       }
-       diag("Server Log:\n$log");
+   my $log_pre = '';
+   if (open my $lfh, '<', "$temp_dir/server.log") {
+       local $/;
+       $log_pre = <$lfh> // '';
+       close $lfh;
    }
+   diag("DEBUG pre-testssl server.log:\n$log_pre");
+   # ---- end DEBUG ----
 
-   # Cleanup: Kill the server process
-   kill 9, $pid;
-   waitpid($pid, 0);
+   my $testssl_output = `./testssl.sh --protocols $listenip:$port 2>&1`;
+
+   like($testssl_output,   qr/TLS 1\.3/,        "TLS 1.3 is supported");
+   unlike($testssl_output, qr/OFFERED\s+TLS 1\.2/, "TLS 1.2 is NOT offered");
+
+   my $log = '';
+   if (open my $lfh, '<', "$temp_dir/server.log") {
+       local $/;
+       $log = <$lfh> // '';
+       close $lfh;
+   }
+   diag("Server Log:\n$log");
 }
-else {
-   die "Fork failed: $!";
-}
 
-
-
+# Cleanup: Kill the server process. When run locally this is needed
+my $openssl_pid = `lsof -i -Pn | grep \$USER | grep openssl | awk '{ print \$2 }'`;
+kill 9, $openssl_pid;
+waitpid($openssl_pid, 0);
 
 done_testing();
 

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -60,7 +60,7 @@ fi
 # Generate self-signed cert and key if they don't exist
 if [ ! -f "$CERT" ] || [ ! -f "$KEY" ]; then
     echo "Generating self-signed certificate and key..."
-    $OPENSSL req -quiet -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null
+    $OPENSSL req -x509 -newkey rsa:2048 -keyout "$KEY" -out "$CERT" -days 42 -nodes -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" >/dev/null
 fi
 
 # Start OpenSSL server

--- a/t/40_tls13.only.t
+++ b/t/40_tls13.only.t
@@ -66,7 +66,7 @@ fi
 # Start OpenSSL server
 echo "Starting server on port $PORT..."
 # $OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -ciphersuites "$CIPHER_SUITE"
-$OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3
+$OPENSSL s_server -accept "$IP:$PORT" -cert "$CERT" -key "$KEY" -tls1_3 -naccept 4242
 
 HEREDOC
 
@@ -84,8 +84,6 @@ if ($pid == 0) {
     chdir($temp_dir)                       or exit 1;
     open(STDOUT, '>', "$temp_dir/server.log") or exit 1;
     open(STDERR, '>&', STDOUT)               or exit 1;
-    pipe(my $r, my $w) or exit 1;            # <-- new
-    open(STDIN,  '<&', $r) or exit 1;        # <-- new
     exec($server_script);
     exit 1;
 }
@@ -150,13 +148,13 @@ elsif ($pid > 0) {
        $log = <$lfh> // '';
        close $lfh;
    }
-   diag("Server Log:\n$log");
+#   diag("Server Log:\n$log");
 }
 
 # Cleanup: Kill the server process. When running locally this is needed
 my $openssl_pid = `lsof -i -Pn | grep \$USER | grep openssl | awk '{ print \$2 }'`;
-kill 9, $openssl_pid;
-waitpid($openssl_pid, 0);
+chomp $openssl_pid;
+if ($openssl_pid) { kill 9, $openssl_pid; waitpid($openssl_pid, 0); }
 
 done_testing();
 


### PR DESCRIPTION
Only the protocol section for now and only . For testing it uses  whatever is the default on each platform, for Linux x64 still the supplied binary, for MacOS the LibreSSL version from MacOS.

https://github.com/testssl/testssl.sh/issues/756#issuecomment-5302724956


## What is your pull request about?
- [ ] Bug fix
- [ ] Improvement
- [ ] New feature (adds functionality)
- [ ] Breaking change: bug fix, feature or improvement that would cause existing output (especially JSON, CSV) to not work as expected before
- [ ] Typo / spelling fix
- [ ] Documentation update
- [x] Update of other files


## If it's a code change please check the boxes which are applicable
- [ ] For the main program: My edits contain no tabs, indentation is five spaces and any line endings do not contain any blank chars
- [x] I've read [CONTRIBUTING.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CONTRIBUTING.md)
- [ ] My code follows [Coding_Convention.md](https://github.com/testssl/testssl.sh/blob/3.3dev/Coding_Convention.md) 
- [ ] I have tested this __fix__ or __improvement__ against >=2 hosts and I couldn't spot a problem
- [ ] I have tested this __new feature__ against >=2 hosts which show this feature and >=2 host which does not (in order to avoid side effects) . I couldn't spot a problem
- [ ] For the __new feature__ I have made corresponding changes to the documentation and / or to ``help()``
- [ ] If it's a bigger change: I added myself to [CREDITS.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CREDITS.md) (alphabetical order of last name) and the change to [CHANGELOG.md](https://github.com/testssl/testssl.sh/blob/3.3dev/CHANGELOG.md)

## AI section
- [ ] I found a bug / an improvement using LLM version: `[e.g. GPT-A.B, Claude <NAME> A.B, Gemini A.B <NAME>, Qwen<B>-Coder, DeepSeek-<A>  etc.]`
- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
    - LLMs and versions: `Qwen-3.6`, `Qwen-3.8`

